### PR TITLE
The package resource name was hardcoded instead of using the value in…

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -58,7 +58,7 @@ class vault::install {
     }
 
     if $vault::install_method == 'repo' {
-      Package['vault'] ~> File_capability['vault_binary_capability']
+      Package[$vault::package_name] ~> File_capability['vault_binary_capability']
     }
   }
 


### PR DESCRIPTION
… $vault::package_name

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Replacing the hardcoded Package resource name with the existing variable used for the package name. This allows the module to work correctly for people using the enterprise package which is not named 'vault'.

#### This Pull Request (PR) fixes the following issues
<!--
n/a
-->
