### PR TITLE
puppetlabs/stdlib: Allow 9.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -73,7 +73,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.24.0 < 9.0.0"
+      "version_requirement": ">= 4.24.0 < 10.0.0"
     },
     {
       "name": "puppet/archive",


### PR DESCRIPTION
Also contains #34 