### PR TITLE
(#29) Fix version is not updated when parameter is changing

### DIFF
--- a/lib/facter/vault_version.rb
+++ b/lib/facter/vault_version.rb
@@ -6,11 +6,10 @@
 #
 Facter.add(:vault_version) do
     setcode do
-      if Facter::Util::Resolution.which('vault')
-        vault_server_version_output = Facter::Util::Resolution.exec('vault version')
-        match = vault_server_version_output.match(%r{Vault v(\d+\.\d+\.\d+)})
-        match ? match.captures.first : nil
-      end
+        if Facter::Util::Resolution.which('vault')
+            vault_server_version_output = Facter::Util::Resolution.exec('vault version')
+            match = vault_server_version_output.match(%r{Vault v(\d+\.\d+\.\d+)})
+            match&.captures.first
+        end
     end
-  end
-  
+end

--- a/lib/facter/vault_version.rb
+++ b/lib/facter/vault_version.rb
@@ -5,11 +5,11 @@
 # Purpose: Retrieve vault version if installed
 #
 Facter.add(:vault_version) do
-    setcode do
-        if Facter::Util::Resolution.which('vault')
-            vault_server_version_output = Facter::Util::Resolution.exec('vault version')
-            match = vault_server_version_output.match(%r{Vault v(\d+\.\d+\.\d+)})
-            match&.captures.first
-        end
+  setcode do
+    if Facter::Util::Resolution.which('vault')
+      vault_server_version_output = Facter::Util::Resolution.exec('vault version')
+      match = vault_server_version_output.match(%r{Vault v(\d+\.\d+\.\d+)})
+      match&.captures&.first
     end
+  end
 end

--- a/lib/facter/vault_version.rb
+++ b/lib/facter/vault_version.rb
@@ -5,7 +5,7 @@
 # Purpose: Retrieve vault version if installed
 #
 Facter.add(:vault_version) do
-  confine {Facter::Util::Resolution.which('vault')}
+  confine { Facter::Util::Resolution.which('vault') }
   setcode do
     vault_server_version_output = Facter::Util::Resolution.exec('vault version')
     match = vault_server_version_output.match(%r{Vault v(\d+\.\d+\.\d+)})

--- a/lib/facter/vault_version.rb
+++ b/lib/facter/vault_version.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Fact: vault_version
+#
+# Purpose: Retrieve vault version if installed
+#
+Facter.add(:vault_version) do
+    setcode do
+      if Facter::Util::Resolution.which('vault')
+        vault_server_version_output = Facter::Util::Resolution.exec('vault version')
+        match = vault_server_version_output.match(%r{Vault v(\d+\.\d+\.\d+)})
+        match ? match.captures.first : nil
+      end
+    end
+  end
+  

--- a/lib/facter/vault_version.rb
+++ b/lib/facter/vault_version.rb
@@ -5,11 +5,10 @@
 # Purpose: Retrieve vault version if installed
 #
 Facter.add(:vault_version) do
+  confine {Facter::Util::Resolution.which('vault')}
   setcode do
-    if Facter::Util::Resolution.which('vault')
-      vault_server_version_output = Facter::Util::Resolution.exec('vault version')
-      match = vault_server_version_output.match(%r{Vault v(\d+\.\d+\.\d+)})
-      match&.captures&.first
-    end
+    vault_server_version_output = Facter::Util::Resolution.exec('vault version')
+    match = vault_server_version_output.match(%r{Vault v(\d+\.\d+\.\d+)})
+    match&.captures&.first
   end
 end

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,7 +19,7 @@ class vault::install {
         extract_path => $vault::bin_dir,
         source       => $vault::real_download_url,
         cleanup      => true,
-        creates      => $facts['vault_version'] ? {  # lint:ignore:selector_inside_resource
+        creates      => $facts['vault_version'] ? { # lint:ignore:selector_inside_resource
           undef   => $vault_bin,
           default => versioncmp($vault::version, $facts['vault_version']) > 0 ? {
             true    => undef,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,7 +19,13 @@ class vault::install {
         extract_path => $vault::bin_dir,
         source       => $vault::real_download_url,
         cleanup      => true,
-        creates      => $vault_bin,
+        creates      => $facts['vault_version'] ? {  # lint:ignore:selector_inside_resource
+          undef   => $vault_bin,
+          default => versioncmp($vault::version, $facts['vault_version']) > 0 ? {
+            true    => undef,
+            default => $vault_bin
+          }
+        },
         before       => File['vault_binary'],
       }
 

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -114,9 +114,9 @@ describe 'vault class' do
       PUPPET
     end
 
-    it 'should not be idempotent and cause changes' do
+    it 'will not be idempotent and cause changes' do
       apply_manifest(manifest, expect_changes: true)
-    end  
+    end
 
     describe command('/usr/local/bin/vault version') do
       its(:exit_status) { is_expected.to eq 0 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -5,6 +5,7 @@
 
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
+ENV['BEAKER_FACTER_VAULT_VERSION'] = '1.12.0'
 configure_beaker(modules: :metadata)
 
 Dir['./spec/support/acceptance/**/*.rb'].sort.each { |f| require f }


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes the issue that version is not updated on parameter change.
This is due the nature of creates parameter in archive.

This PR is creating a fact of vaults version and compares it against the parameter.
If parameter is newer it will download the archive and extract it.

This will not reboot vault server.
Please be aware to restart vault server, so vault sources the new binary.

#### This Pull Request (PR) fixes the following issues
Fixes #29 
