### PR TITLE
Add Systemd Parameter MemorySwapMax to template

### DIFF
--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -42,6 +42,7 @@ KillMode=process
 RestartSec=5
 LimitNOFILE=65536
 LimitCORE=0
+MemorySwapMax=0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
#### Pull Request (PR) description

This PR continues with Vault Service Hardening and implements SystemDs parameter **MemorySwapMax**.
Based on the recommendations, swap should be disabled for the whole system.
Since in some cases this cannot be achieved so easily, we add this parameter to at least ensure that the vault service, does not swap.