### PR TITLE
Adding hcl as an output option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,4 +26,6 @@ gem 'rake', :require => false
 
 gem 'openvox', ENV.fetch('OPENVOX_GEM_VERSION', [">= 7", "< 9"]), :require => false, :groups => [:test]
 
+gem 'puppet-hcl', git: 'https://github.com/avitacco/puppet-hcl', tag: 'v1.0.0'
+
 # vim: syntax=ruby

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -17,6 +17,10 @@
 * `vault::params`: This class is meant to be called from vault. It sets variables according to platform.
 * `vault::service`
 
+### Functions
+
+* [`vault::to_hcl`](#vault--to_hcl): Converts a Vault configuration hash to HCL format.
+
 ## Classes
 
 ### <a name="vault"></a>`vault`
@@ -33,6 +37,7 @@ The following parameters are available in the `vault` class:
 * [`manage_group`](#-vault--manage_group)
 * [`bin_dir`](#-vault--bin_dir)
 * [`bin_name`](#-vault--bin_name)
+* [`config_format`](#-vault--config_format)
 * [`config_dir`](#-vault--config_dir)
 * [`config_filename`](#-vault--config_filename)
 * [`config_mode`](#-vault--config_mode)
@@ -135,6 +140,14 @@ The binary name which is used (e.g vault) can be set to bao if you want to use o
 
 Default value: `'vault'`
 
+##### <a name="-vault--config_format"></a>`config_format`
+
+Data type: `Enum['hcl','json']`
+
+The format the config should use (hcl or json), default json
+
+Default value: `'json'`
+
 ##### <a name="-vault--config_dir"></a>`config_dir`
 
 Data type: `Any`
@@ -147,9 +160,9 @@ Default value: `if $install_method == 'repo' and $manage_repo { '/etc/vault.d' }
 
 Data type: `Any`
 
-Filename for the vault configuration. Defaults to 'config.json'
+Filename for the vault configuration. Defaults to 'config.config_format'
 
-Default value: `'config.json'`
+Default value: `"config.${config_format}"`
 
 ##### <a name="-vault--config_mode"></a>`config_mode`
 
@@ -567,4 +580,40 @@ Data type: `Optional[Hash]`
 Hash containing telemetry configuration for agent mode
 
 Default value: `undef`
+
+## Functions
+
+### <a name="vault--to_hcl"></a>`vault::to_hcl`
+
+Type: Ruby 4.x API
+
+Converts a Vault configuration hash to HCL format.
+
+#### Examples
+
+##### Converting a config hash to HCL
+
+```puppet
+$hcl_content = vault::to_hcl($config_hash)
+```
+
+#### `vault::to_hcl(Hash $config)`
+
+The vault::to_hcl function.
+
+Returns: `String` The Vault configuration rendered as HCL.
+
+##### Examples
+
+###### Converting a config hash to HCL
+
+```puppet
+$hcl_content = vault::to_hcl($config_hash)
+```
+
+##### `config`
+
+Data type: `Hash`
+
+A hash containing the Vault configuration.
 

--- a/lib/puppet/functions/vault/to_hcl.rb
+++ b/lib/puppet/functions/vault/to_hcl.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative '../../vault_config/schema'
+
+# @summary Converts a Vault configuration hash to HCL format.
+Puppet::Functions.create_function(:'vault::to_hcl') do
+  # Converts a Vault configuration hash to HCL format.
+  #
+  # @param config A hash containing the Vault configuration.
+  # @return [String] The Vault configuration rendered as HCL.
+  # @example Converting a config hash to HCL
+  #   $hcl_content = vault::to_hcl($config_hash)
+  dispatch :to_hcl do
+    param 'Hash', :config
+    return_type 'String'
+  end
+
+  def to_hcl(config)
+    require 'puppet/hcl'
+    Puppet::HCL.generate(
+      transform(config),
+      labeled_blocks: Puppet::VaultConfig::LABELED_BLOCKS.map(&:to_sym),
+    )
+  end
+
+  private
+
+  def transform(config)
+    config.each_with_object({}) do |(key, value), result|
+      result[key.to_sym] = if Puppet::VaultConfig::LABELED_BLOCKS.include?(key)
+                             Array(value).map { |item| labeled_block(item) }
+                           else
+                             deep_symbolize(value)
+                           end
+    end
+  end
+
+  def labeled_block(item)
+    if item.is_a?(Hash)
+      type, attrs = item.first
+    else
+      # item is a [type, attrs] pair produced by Array(hash).to_a
+      # This happens when a labeled block param (e.g. storage) is passed as a
+      # plain Hash rather than an Array of single-key hashes.
+      type, attrs = item
+    end
+    deep_symbolize(attrs).merge(_label: type)
+  end
+
+  def deep_symbolize(value)
+    case value
+    when Hash
+      value.each_with_object({}) do |(k, v), h|
+        h[k.to_sym] = deep_symbolize(v)
+      end
+    when Array
+      value.map { |v| deep_symbolize(v) }
+    else
+      value
+    end
+  end
+end

--- a/lib/puppet/vault_config/schema.rb
+++ b/lib/puppet/vault_config/schema.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Puppet
+  module VaultConfig
+    LABELED_BLOCKS = %w[listener storage seal ha_storage entropy].freeze
+  end
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -53,11 +53,26 @@ class vault::config {
 
     $config_hash = $_config_hash + $vault::extra_config
 
-    file { "${vault::config_dir}/${vault::config_filename}":
-      content => stdlib::to_json_pretty($config_hash),
-      owner   => $vault::user,
-      group   => $vault::group,
-      mode    => $vault::config_mode,
+    case $vault::config_format {
+      'json': {
+        file { "${vault::config_dir}/${vault::config_filename}":
+          content => stdlib::to_json_pretty($config_hash),
+          owner   => $vault::user,
+          group   => $vault::group,
+          mode    => $vault::config_mode,
+        }
+      }
+      'hcl': {
+        file { "${vault::config_dir}/${vault::config_filename}":
+          content => vault::to_hcl($config_hash),
+          owner   => $vault::user,
+          group   => $vault::group,
+          mode    => $vault::config_mode,
+        }
+      }
+      default: {
+        fail("Unsupported config_format: ${vault::config_format}")
+      }
     }
 
     # If manage_storage_dir is true and a file or raft storage backend is

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,9 +13,11 @@
 #
 # @param bin_name The binary name which is used (e.g vault) can be set to bao if you want to use openbao
 #
+# @param config_format The format the config should use (hcl or json), default json
+#
 # @param config_dir Directory the vault configuration will be kept in.
 #
-# @param config_filename Filename for the vault configuration. Defaults to 'config.json'
+# @param config_filename Filename for the vault configuration. Defaults to 'config.config_format'
 #
 # @param config_mode Mode of the configuration file (config.json). Defaults to '0750'
 #
@@ -129,8 +131,9 @@ class vault (
   $service_options                       = '',
   $num_procs                             = $facts['processors']['count'],
   $install_method                        = $vault::params::install_method,
+  Enum['hcl','json'] $config_format      = 'json',
   $config_dir                            = if $install_method == 'repo' and $manage_repo { '/etc/vault.d' } else { '/etc/vault' },
-  $config_filename                       = 'config.json',
+  $config_filename                       = "config.${config_format}",
   Boolean $manage_package                = true,
   $package_name                          = 'vault',
   $package_ensure                        = 'installed',

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -473,6 +473,137 @@ describe 'vault' do
         end
       end
 
+      context 'when config_format is hcl' do
+        let(:params) do
+          {
+            config_format: 'hcl',
+            storage: {
+              'file' => {
+                'path' => '/data/vault',
+              },
+            },
+            listener: {
+              'tcp' => {
+                'address'     => '127.0.0.1:8200',
+                'tls_disable' => 1,
+              },
+            },
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it {
+          is_expected.to contain_file('/etc/vault/config.hcl')
+            .with_owner('vault')
+            .with_group('vault')
+        }
+
+        context 'vault HCL config' do
+          subject { param_value(catalogue, 'File', '/etc/vault/config.hcl', 'content') }
+
+          it { is_expected.to match(%r{^listener "tcp" \{}) }
+          it { is_expected.to match(%r{address\s+=\s+"127\.0\.0\.1:8200"}) }
+          it { is_expected.to match(%r{tls_disable\s+=\s+1}) }
+          it { is_expected.to match(%r{^storage "file" \{}) }
+          it { is_expected.to match(%r{path\s+=\s+"/data/vault"}) }
+        end
+
+        context 'with multiple listeners' do
+          subject { param_value(catalogue, 'File', '/etc/vault/config.hcl', 'content') }
+
+          let(:params) do
+            super().merge(
+              listener: [
+                { 'tcp' => { 'address' => '127.0.0.1:8200' } },
+                { 'tcp' => { 'address' => '0.0.0.0:8200' } },
+              ],
+            )
+          end
+
+          it { is_expected.to match(%r{listener "tcp".*127\.0\.0\.1:8200}m) }
+          it { is_expected.to match(%r{listener "tcp".*0\.0\.0\.0:8200}m) }
+        end
+
+        context 'with a seal block' do
+          subject { param_value(catalogue, 'File', '/etc/vault/config.hcl', 'content') }
+
+          let(:params) do
+            super().merge(
+              seal: {
+                'awskms' => {
+                  'region'     => 'us-east-1',
+                  'kms_key_id' => 'my-key-id',
+                },
+              },
+            )
+          end
+
+          it { is_expected.to match(%r{^seal "awskms" \{}) }
+          it { is_expected.to match(%r{region\s+=\s+"us-east-1"}) }
+          it { is_expected.to match(%r{kms_key_id\s+=\s+"my-key-id"}) }
+        end
+
+        context 'with raft storage and manage_storage_dir' do
+          subject { param_value(catalogue, 'File', '/etc/vault/config.hcl', 'content') }
+
+          let(:params) do
+            {
+              config_format:      'hcl',
+              manage_storage_dir: true,
+              storage: {
+                'raft' => {
+                  'path'    => '/data/vault',
+                  'node_id' => 'vault1',
+                },
+              },
+            }
+          end
+
+          it {
+            expect(catalogue).to contain_file('/data/vault')
+              .with_ensure('directory')
+              .with_owner('vault')
+              .with_group('vault')
+          }
+
+          it { is_expected.to match(%r{^storage "raft" \{}) }
+          it { is_expected.to match(%r{node_id\s+=\s+"vault1"}) }
+        end
+
+        context 'with disable_mlock' do
+          subject { param_value(catalogue, 'File', '/etc/vault/config.hcl', 'content') }
+
+          let(:params) do
+            super().merge(disable_mlock: true)
+          end
+
+          it { is_expected.to match(%r{disable_mlock\s+=\s+true}) }
+        end
+
+        context 'with config mode' do
+          let(:params) do
+            super().merge(config_mode: '0700')
+          end
+
+          it { is_expected.to contain_file('/etc/vault/config.hcl').with_mode('0700') }
+        end
+
+        context 'excludes unconfigured options' do
+          subject { param_value(catalogue, 'File', '/etc/vault/config.hcl', 'content') }
+
+          it { is_expected.not_to match(%r{ha_storage}) }
+          it { is_expected.not_to match(%r{seal}) }
+          it { is_expected.not_to match(%r{disable_cache}) }
+          it { is_expected.not_to match(%r{telemetry}) }
+          it { is_expected.not_to match(%r{default_lease_ttl}) }
+          it { is_expected.not_to match(%r{max_lease_ttl}) }
+          it { is_expected.not_to match(%r{disable_mlock}) }
+          it { is_expected.not_to match(%r{^ui\s}) }
+          it { is_expected.not_to match(%r{api_addr}) }
+        end
+      end
+
       case os_facts[:os]['family']
       when 'RedHat'
         case os_facts[:os]['release']['major'].to_i

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -551,7 +551,7 @@ describe 'vault' do
             {
               config_format:      'hcl',
               manage_storage_dir: true,
-              storage: {
+              storage:            {
                 'raft' => {
                   'path'    => '/data/vault',
                   'node_id' => 'vault1',


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds hcl as an optional output format

* Including a ruby module specifically created to create HCL from Ruby data structures
* Added a param to init.pp for config format with a default to json so that the default behavior of this module remains unchanged
* Added logic in config.pp to handle different output formats
* Added tests for new hcl output functionality
* Added two new files (`to_hcl.rb` and `schema.rb`) to help support the hcl output
* Updated the REFERENCE.md file for new functionality

#### This Pull Request (PR) fixes the following issues
Fixes #18 

