### PR TITLE
Add service_read_write_paths parameter for systemd ReadWritePaths

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -43,6 +43,7 @@ The following parameters are available in the `vault` class:
 * [`service_name`](#-vault--service_name)
 * [`service_provider`](#-vault--service_provider)
 * [`service_options`](#-vault--service_options)
+* [`service_read_write_paths`](#-vault--service_read_write_paths)
 * [`manage_repo`](#-vault--manage_repo)
 * [`manage_service`](#-vault--manage_service)
 * [`num_procs`](#-vault--num_procs)
@@ -215,6 +216,16 @@ Data type: `Any`
 Extra argument to pass to `vault server`, as per: `vault server --help`
 
 Default value: `''`
+
+##### <a name="-vault--service_read_write_paths"></a>`service_read_write_paths`
+
+Data type: `Array[Stdlib::Absolutepath]`
+
+List of absolute paths added to the systemd service unit `ReadWritePaths=`
+directive, allowing the Vault/OpenBao process to write to these paths despite
+`ProtectSystem`/`ProtectHome` hardening. Empty by default (directive omitted).
+
+Default value: `[]`
 
 ##### <a name="-vault--manage_repo"></a>`manage_repo`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,11 @@
 #
 # @param service_options Extra argument to pass to `vault server`, as per: `vault server --help`
 #
+# @param service_read_write_paths
+#   List of absolute paths added to the systemd service unit `ReadWritePaths=`
+#   directive, allowing the Vault/OpenBao process to write to these paths despite
+#   `ProtectSystem`/`ProtectHome` hardening. Empty by default (directive omitted).
+#
 # @param manage_repo Configure the upstream HashiCorp repository. Only relevant when $nomad::install_method = 'repo'.
 #
 # @param manage_service Instruct puppet to manage service or not
@@ -127,6 +132,7 @@ class vault (
   $disable_mlock                         = undef,
   $manage_file_capabilities              = undef,
   $service_options                       = '',
+  Array[Stdlib::Absolutepath] $service_read_write_paths = [],
   $num_procs                             = $facts['processors']['count'],
   $install_method                        = $vault::params::install_method,
   $config_dir                            = if $install_method == 'repo' and $manage_repo { '/etc/vault.d' } else { '/etc/vault' },

--- a/spec/classes/vault_spec.rb
+++ b/spec/classes/vault_spec.rb
@@ -494,6 +494,29 @@ describe 'vault' do
                   .with_content(%r{Capabilities=CAP_IPC_LOCK\+ep})
                   .with_content(%r{CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK})
                   .with_content(%r{NoNewPrivileges=yes})
+                  .without_content(%r{ReadWritePaths})
+              }
+            end
+
+            context 'with service_read_write_paths set' do
+              let(:params) do
+                { service_read_write_paths: ['/srv/vault/data', '/var/log/vault'] }
+              end
+
+              it {
+                is_expected.to contain_file('/etc/systemd/system/vault.service')
+                  .with_content(%r{^ReadWritePaths=/srv/vault/data /var/log/vault$})
+              }
+            end
+
+            context 'with service_read_write_paths set to an empty array' do
+              let(:params) do
+                { service_read_write_paths: [] }
+              end
+
+              it {
+                is_expected.to contain_file('/etc/systemd/system/vault.service')
+                  .without_content(%r{ReadWritePaths})
               }
             end
 
@@ -691,6 +714,29 @@ describe 'vault' do
                   .with_content(%r{Capabilities=CAP_IPC_LOCK\+ep})
                   .with_content(%r{CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK})
                   .with_content(%r{NoNewPrivileges=yes})
+                  .without_content(%r{ReadWritePaths})
+              }
+            end
+
+            context 'with service_read_write_paths set' do
+              let(:params) do
+                { service_read_write_paths: ['/srv/vault/data', '/var/log/vault'] }
+              end
+
+              it {
+                is_expected.to contain_file('/etc/systemd/system/vault.service')
+                  .with_content(%r{^ReadWritePaths=/srv/vault/data /var/log/vault$})
+              }
+            end
+
+            context 'with service_read_write_paths set to an empty array' do
+              let(:params) do
+                { service_read_write_paths: [] }
+              end
+
+              it {
+                is_expected.to contain_file('/etc/systemd/system/vault.service')
+                  .without_content(%r{ReadWritePaths})
               }
             end
 

--- a/templates/vault.systemd.erb
+++ b/templates/vault.systemd.erb
@@ -20,6 +20,10 @@ PrivateDevices=yes
 PrivateTmp=yes
 ProtectSystem=full
 ProtectHome=read-only
+<% rwp = scope['vault::service_read_write_paths'] -%>
+<% unless rwp.empty? -%>
+ReadWritePaths=<%= rwp.join(' ') %>
+<% end -%>
 <% # Still require check for :undef for Puppet 3.x -%>
 <% if scope['vault::disable_mlock'] && scope['vault::disable_mlock'] != :undef -%>
 CapabilityBoundingSet=CAP_SYSLOG


### PR DESCRIPTION
The generated systemd unit applies hardening (ProtectSystem=full, ProtectHome=read-only) that makes most of the filesystem read-only for the process. In agent mode Vault/OpenBao needs to write to specific directories (token sinks, rendered templates, cache). This adds an optional `read_write_paths` parameter that populates the systemd `ReadWritePaths=` directive, rendered only when paths are provided so the default unit is unchanged.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adds an optional `read_write_paths` parameter that populates the `ReadWritePaths=` directive of the systemd unit's `[Service]` section.

This allows the Vault/OpenBao process to write to specific directories despite the existing `ProtectSystem`/`ProtectHome` hardening — useful
notably in agent mode (token sinks, rendered templates, cache).

Type: `Optional[Array[Stdlib::Absolutepath]]`, default `undef`. When unset/empty the directive is omitted, so the default unit is unchanged (backwards compatible).

Example:
  class { 'vault':
    mode             => 'agent',
    read_write_paths => ['/srv/vault/data', '/var/log/vault'],
  }

#### This Pull Request (PR) fixes the following issues
N/A
